### PR TITLE
Update travel-guide-2-secure-approvals.md

### DIFF
--- a/_pages/policies/travel-and-leave-policies/travel-guide-2-secure-approvals.md
+++ b/_pages/policies/travel-and-leave-policies/travel-guide-2-secure-approvals.md
@@ -2,8 +2,8 @@
 title: Step 2 - Secure approvals
 ---
 
-[TOC](/travel-guide-table-of-contents)
-[Back to Book Travel in Concur](/travel-guide-1-book-travel)
+[TOC](/travel-guide-table-of-contents) <br>
+[Back to Book Travel in Concur](/travel-guide-1-book-travel) <br>
 [Jump to Travel](/travel-guide-3-travel)
 
 ## Brief overview of securing approvals


### PR DESCRIPTION
Should the email templates go in a separate document or documents?  It seems like the middle of this handbook page is an odd place to find them.  Should we pull questions from the different parts of this doc and put them together in a general FAQ section.  There are so many questions that its a little distracting from the larger process.